### PR TITLE
Fix broken local builds

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -216,7 +216,7 @@ gulp.task('html', () =>
     .pipe(htmlmin({
       collapseWhitespace: true,
       processConditionalComments: true,
-      minifyJS: true,
+      // minifyJS: true, // CAUSES BUG and also appears to be unnecessary as scripts seem to be minified already
     }))
     .pipe(gulp.dest('dist'))
 );


### PR DESCRIPTION
@joannaskao @aendrew @tomgp 

Weird bug reported by Jo this morning: when you make a production build locally, you get broken clientside JavaScript. But it works fine when built from CI.

Commenting out a single line in the gulpfile seems to fix it. The culprit seems to be the HTML minifier when it tries to minify the inlined top.js script inside the HTML – when run on a local dev machine, it seems to delete the addScript function. No idea why it would work differently in CI though.

Also, the script seems to be already minified before it gets inlined, so that extra minification was redundant anyway.

Also [fixed upstream in starter-kit](https://github.com/ft-interactive/starter-kit/commit/cbae0ee52c5e6b223a648b169a3fc2df2c25de53).